### PR TITLE
Fix scheme typecasting in uri.rb

### DIFF
--- a/mrblib/uri.rb
+++ b/mrblib/uri.rb
@@ -6,8 +6,8 @@ module URI
     def initialize(schema, host, port, path, query, fragment, userinfo, uri)
       @schema, @host, @port, @path, @query, @fragment, @userinfo, @uri = schema, host, port, path, query, fragment, userinfo, uri
 
-      unless port
-        @port = URI.get_port(String(schema).downcase)
+      if port.nil? && !schema.nil?
+        @port = URI.get_port(schema.downcase)
       end
     end
 


### PR DESCRIPTION
Use `#to_s` instead of `String(...)`, which causes error (running within mruby-cli container):

```
/home/mruby/code/mruby/build/mrbgems/mruby-uri-parser/mrblib/uri.rb:10: undefined method 'String' for #<URI::Parsed:0x25e2b90> (NoMethodError)
```

